### PR TITLE
cgi.parse_qs is deprecated

### DIFF
--- a/svc/services.py
+++ b/svc/services.py
@@ -63,7 +63,7 @@ def application(environ, start_response):
             form[field] = t
         label = not label
 
-    form["query_string"] = cgi.parse_qs(environ['QUERY_STRING'])
+    form["query_string"] = urllib.parse.parse_qs(environ['QUERY_STRING'])
 
     # This MAC header is set by anaconda during a kickstart booted with the
     # kssendmac kernel option. The field will appear here as something


### PR DESCRIPTION
From https://docs.python.org/3.2/library/cgi.html:
cgi.parse_qs(qs, keep_blank_values=False, strict_parsing=False)
    This function is deprecated in this module. Use urllib.parse.parse_qs() instead. It is maintained here only for backward compatibility.

urllib.parse.parse_qs also works in the python-2.7 (cobbler-2.8.5)